### PR TITLE
Add header param support

### DIFF
--- a/src/main/scala/com/sumologic/terraform_generator/TerraformGenerator.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/TerraformGenerator.scala
@@ -45,7 +45,7 @@ object TerraformGenerator extends StringHelper {
     ProviderFileGenerator(terraforms.map(_._2)).writeToFile(resourcesDirectory + "provider.go")
   }
 
-  def writeFiles(sumoSwaggerTemplate: ScalaSwaggerTemplate, baseType: String) = {
+  def writeFiles(sumoSwaggerTemplate: ScalaSwaggerTemplate, baseType: String): Unit = {
     val genSumoClass = TerraformClassFileGenerator(sumoSwaggerTemplate)
     val terraformTypeName = removeCamelCase(baseType)
 

--- a/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerObject.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerObject.scala
@@ -75,7 +75,7 @@ case class ScalaSwaggerObjectSingle(name: String,
                                     required: Boolean,
                                     defaultOpt: Option[AnyRef],
                                     description: String,
-                                    example: String,
+                                    example: String = "",
                                     createOnly: Boolean = false) extends
   ScalaSwaggerObject(name: String, objType: ScalaSwaggerType, required: Boolean, defaultOpt: Option[AnyRef], description, example, createOnly) {
   override def terraformify(): String = {

--- a/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerTemplate.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/ScalaSwaggerTemplate.scala
@@ -137,8 +137,11 @@ case class ScalaSwaggerTemplate(sumoSwaggerClassName: String,
 
     // Only supporting query params for now. Assuming path parameters in CRUD endpoints will only be id. Not supporting header parameters yet.
 
-    val requestMaps = supportedEndpoints.filter {
-      endpoint => endpoint.parameters.map(_.paramType).contains(TerraformSupportedParameterTypes.QueryParameter)
+    val requestMaps = supportedEndpoints.filter { endpoint =>
+      val paramTypes = endpoint.parameters.map(_.paramType)
+      paramTypes.exists { x =>
+        x == TerraformSupportedParameterTypes.QueryParameter || x == TerraformSupportedParameterTypes.HeaderParameter
+      }
     }.map {
       endpoint =>
         "\"" + s"${endpoint.httpMethod.toLowerCase}_request_map" + "\"" + s": {\n           Type: schema.TypeMap,\n          Optional: true,\n           Elem: &schema.Schema{\n            Type: schema.TypeString,\n            },\n         }"

--- a/src/main/scala/com/sumologic/terraform_generator/objects/SumoSwaggerEndpointHelper.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/SumoSwaggerEndpointHelper.scala
@@ -23,7 +23,12 @@ trait SumoSwaggerEndpointHelper extends StringHelper {
 
   def getArgsListForDecl(params: List[ScalaSwaggerParameter]): List[String] = {
     // TODO val queryParamList = params.filter(_.paramType == SumoTerraformSupportedParameterTypes.QueryParameter)
-    val requestMap = if (params.map(_.paramType).contains(TerraformSupportedParameterTypes.QueryParameter)) {
+
+    val hasParams = params.map(_.paramType).exists { paramType =>
+      paramType.equals(TerraformSupportedParameterTypes.QueryParameter) ||
+          paramType.equals(TerraformSupportedParameterTypes.HeaderParameter)
+    }
+    val requestMap = if (hasParams) {
       List("paramMap map[string]string")
     } else {
       List.empty[String]

--- a/src/main/scala/com/sumologic/terraform_generator/objects/SumoSwaggerTerraformHelperObjects.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/objects/SumoSwaggerTerraformHelperObjects.scala
@@ -66,4 +66,5 @@ object TerraformSupportedParameterTypes {
   final val PathParameter = "PathParameter"
   final val BodyParameter = "BodyParameter"
   final val QueryParameter = "QueryParameter"
+  final val HeaderParameter = "HeaderParameter"
 }

--- a/src/main/scala/com/sumologic/terraform_generator/utils/OpenApiProcessor.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/utils/OpenApiProcessor.scala
@@ -3,7 +3,7 @@ package com.sumologic.terraform_generator.utils
 import com.sumologic.terraform_generator.objects.{ScalaSwaggerEndpoint, ScalaSwaggerObject, ScalaSwaggerObjectArray, ScalaSwaggerObjectSingle, ScalaSwaggerParameter, ScalaSwaggerResponse, ScalaSwaggerTemplate, ScalaSwaggerType, TerraformSchemaTypes, TerraformSupportedParameterTypes}
 import io.swagger.v3.oas.models.PathItem.HttpMethod
 import io.swagger.v3.oas.models.media.{ArraySchema, ComposedSchema, Schema}
-import io.swagger.v3.oas.models.parameters.{Parameter, PathParameter, QueryParameter}
+import io.swagger.v3.oas.models.parameters.{HeaderParameter, Parameter, PathParameter, QueryParameter}
 import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.{OpenAPI, Operation, PathItem}
 
@@ -76,6 +76,19 @@ object OpenApiProcessor extends ProcessorHelper {
       ScalaSwaggerObjectSingle(queryParam.getName,
         ScalaSwaggerType(queryParam.getSchema.getType, List[ScalaSwaggerObject]()),
         queryParam.getRequired, Some(queryParam.getSchema.getDefault.asInstanceOf[AnyRef]), queryParam.getSchema.getDescription, ""))
+  }
+
+  def processHeaderParameter(openApi: OpenAPI, headerParam: HeaderParameter): ScalaSwaggerParameter = {
+    ScalaSwaggerParameter(
+      TerraformSupportedParameterTypes.HeaderParameter,
+      ScalaSwaggerObjectSingle(
+        headerParam.getName,
+        ScalaSwaggerType(headerParam.getSchema.getType, List[ScalaSwaggerObject]()),
+        headerParam.getRequired,
+        Some(headerParam.getSchema.getDefault.asInstanceOf[AnyRef]),
+        headerParam.getSchema.getDescription
+      )
+    )
   }
 
   def processBodyParameter(openApi: OpenAPI, bodyParam: Schema[_]): List[ScalaSwaggerParameter] = {
@@ -207,6 +220,8 @@ object OpenApiProcessor extends ProcessorHelper {
             List(processPathParameter(openApi, pathParam))
           case queryParam: QueryParameter =>
             List(processQueryParameter(openApi, queryParam))
+          case headerParam: HeaderParameter =>
+            List(processHeaderParameter(openApi, headerParam))
           case _ =>
             if (param.getIn == null && param.getContent != null) {
               processBodyParameter(openApi, param.getSchema)

--- a/src/main/scala/com/sumologic/terraform_generator/writer/TerraformResourceFileGenerator.scala
+++ b/src/main/scala/com/sumologic/terraform_generator/writer/TerraformResourceFileGenerator.scala
@@ -53,7 +53,12 @@ case class ResourceFunctionGenerator(endpoint: ScalaSwaggerEndpoint, mainClass: 
   val className = mainClass.name
   val objName = lowerCaseFirstLetter(className)
 
-  val requestMap = if (endpoint.parameters.map(_.paramType).contains(TerraformSupportedParameterTypes.QueryParameter)) {
+  val hasParams = endpoint.parameters.map(_.paramType).exists { param =>
+    param.contains(TerraformSupportedParameterTypes.QueryParameter) ||
+        param.contains(TerraformSupportedParameterTypes.HeaderParameter)
+  }
+
+  val requestMap = if (hasParams) {
     s"""requestParams := make(map[string]string)
        |	for k, v := range d.Get("${endpoint.httpMethod.toLowerCase}_request_map").(map[string]interface{}) {
        |		requestParams[k] = v.(string)


### PR DESCRIPTION
Yaml
```yaml
  extractionRuleId:
    delete:
      x-tf-delete: true
      summary: Delete a field extraction rule.
      description: Delete a field extraction rule with the given identifier.
      operationId: deleteExtractionRule
      tags:
      - extractionRuleManagement
      parameters:
      - name: id
        description: Identifier of the field extraction rule to delete.
        required: true
        in: path
        schema:
          type: string
      - name: firstHeaderParam
        description: first header param
        required: false
        in: header
        schema:
          type: string
      - name: secondHeaderParam
        description: second header param
        required: false
        in: header
        schema:
          type: string
      responses:
        204:
          description: Extraction rule was deleted successfully.
```


Generated code:
```go
func (s *Client) DeleteExtractionRule(id string, paramMap map[string]string) error {
  urlWithoutParams := "v1/extractionRules"
  paramString := ""
  sprintfArgs := []interface{}{}
  sprintfArgs = append(sprintfArgs, id)
  paramString += "/%s"

  urlWithParams := fmt.Sprintf(urlWithoutParams + paramString, sprintfArgs...)

  reqHeaders := make(map[string]string)
  if val, ok := paramMap["firstHeaderParam"]; ok {
    reqHeaders["firstHeaderParam"] = val
  }
  if val, ok := paramMap["secondHeaderParam"]; ok {
    reqHeaders["secondHeaderParam"] = val
  }

  _, err := s.Delete(urlWithParams)

  return err
}
```